### PR TITLE
Add redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,8 @@
 title: Page not found
 jumbotron: credits
 layout: default
+redirect_from:
+  - /404/
 ---
 
 <img style="float:left;margin: -10px 40px 0 0;"

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+permalink: /:title.html
+gems:
+  - jekyll-redirect-from

--- a/community.html
+++ b/community.html
@@ -1,6 +1,8 @@
 ---
 title: Community
 layout: default
+redirect_from:
+  - /community/
 ---
 
 <h1>Get involved</h1>

--- a/credits.html
+++ b/credits.html
@@ -1,6 +1,9 @@
 ---
 title: Credits
 layout: default
+redirect_from:
+  - /credits/
+  - /contributors/
 ---
 
 <h2>Core Developers</h2>

--- a/customize.html
+++ b/customize.html
@@ -1,6 +1,12 @@
 ---
 title: Customize
 layout: default
+redirect_from:
+  - /customize/
+  - /mods/
+  - /games/
+  - /subgames/
+  - /texturepacks/
 ---
 
 <h1 id="subgames">Subgames</h1>

--- a/development.html
+++ b/development.html
@@ -1,6 +1,11 @@
 ---
 title: Development
 layout: default
+redirect_from:
+  - /development/
+  - /reporting_issues/
+  - /donate/
+  - /support/
 ---
 
 <h1>Overview</h1>

--- a/downloads.html
+++ b/downloads.html
@@ -1,6 +1,11 @@
 ---
 title: Download
 layout: default
+redirect_from:
+  - /downloads/
+  - /download/
+  - /old_releases/
+  - /other_distros/
 ---
 
 <p class="intro">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 ---
 title: Home
+redirect_from:
+  - /index/
+  - /screenshots/
 ---
 
 {% include header.html %}

--- a/irc.html
+++ b/irc.html
@@ -2,6 +2,8 @@
 title: Community
 jumbotron: IRC
 layout: default
+redirect_from:
+  - /irc/
 ---
 
 <h1>Channels</h1>


### PR DESCRIPTION
This should solve all of the broken links and they now redirect to the appropriate new pages.
Also fixes #3.

This adds the [Pageless Redirect Generator](https://github.com/nquinlan/jekyll-pageless-redirects) for jekyll. This is so we can set up future redirects with one simple line in (rather than adding lots of pages).