### PR TITLE
Fix broken link on some external websites

### DIFF
--- a/download.php
+++ b/download.php
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Redirecting...</title>
+<link rel=canonical href="http://www.minetest.net/downloads/">
+<meta http-equiv=refresh content="0; url=http://www.minetest.net/downloads/">
+<h1>Redirecting...</h1>
+<a href="http://www.minetest.net/downloads/">Click here if you are not redirected.</a>
+<script>location='http://www.minetest.net/downloads/'</script>


### PR DESCRIPTION
Some 3rd-party websites (e.g. http://www.techspot.com/downloads/5585-minetest.html: the 'linux' option) link to http://minetest.net/download.php, and not http://minetest.net/downloads.