### PR TITLE
Remove "About this website" section from community.html

### DIFF
--- a/community.html
+++ b/community.html
@@ -18,20 +18,3 @@ redirect_from:
   <li>Talk about Minetest on <a href="http://www.reddit.com/r/Minetest">reddit</a></li>
   <li>Perform some <a href="/development/">development</a></li>
 </ul>
-
-<div class="line"></div>
-<h1>About this website</h1>
-
-<p>
-  This website is created and updated by members of the Minetest community
-  (PilzAdam, rubenwardy, xyz, Jordach, BlockMen, ShadowNinja, nrz),
-  administrated by celeron55. It was redesigned by Calinou in 2015.
-</p>
-
-<p>
-  <a href="//www.minetest.net">minetest.net</a> and <a href="https://forum.minetest.net">forum.minetest.net</a> are currently hosted by celeron55 in the Netherlands.
-</p>
-
-<p>
-  If you find problems or think something needs to be updated on this website, please contact us on <a href="/irc/">IRC</a> or <a href="https://forum.minetest.net">forums</a>.
-</p>


### PR DESCRIPTION
This removes the "About this website" section from communiy.html as discussed in issue #31 .