### PR TITLE
Fix broken link on some external websites

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -4,6 +4,8 @@ layout: default
 redirect_from:
   - /downloads.html
   - /download/
+  - /download.php
+  - /downloads.php
   - /old_releases/
   - /other_distros/
 ---


### PR DESCRIPTION
Some 3rd-party websites (e.g. http://www.techspot.com/downloads/5585-minetest.html: the 'linux' option) link to http://minetest.net/download.php, and not http://minetest.net/downloads.