### PR TITLE
Make internal links HTTPS ready

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -11,7 +11,7 @@ redirect_from:
 
 <h1 id="subgames">Subgames</h1>
 <p>
-  <a href="http://wiki.minetest.net/Subgames">Subgames</a> form a foundation for the game.  Different subgames have different objectives – such as survival, building, or player vs. player.
+  <a href="//wiki.minetest.net/Subgames">Subgames</a> form a foundation for the game.  Different subgames have different objectives – such as survival, building, or player vs. player.
   Usually Minetest comes with minetest_game, which supplies the default items.
 </p>
 
@@ -21,7 +21,7 @@ redirect_from:
   <li><a href="https://forum.minetest.net/viewtopic.php?t=9196">Dreambuilder</a> - A building based game, includes many building materials.</li>
   <li><a href="https://forum.minetest.net/viewtopic.php?t=12824">Carbone NG</a> - Focuses on “optimization, game balance, fun and intuitiveness.”</li>
   <li><a href="https://forum.minetest.net/viewtopic.php?t=9036">Big Freaking Dig</a> - “Get as many ores as possible, while fighting mobs and creating tools from new materials.”</li>
-  <li><a href="http://wiki.minetest.net/Games/Tutorial">Tutorial</a> - “Teaches the fundamental basics of Minetest”</li>
+  <li><a href="//wiki.minetest.net/Games/Tutorial">Tutorial</a> - “Teaches the fundamental basics of Minetest”</li>
 </ul>
 
 <p>
@@ -40,7 +40,7 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
 </p>
 
 <p>
-  Learn how to <a href="http://dev.minetest.net/Installing_Mods">install and use mods</a>.
+  Learn how to <a href="//dev.minetest.net/Installing_Mods">install and use mods</a>.
 </p>
 
 <h2>Popular mods</h2>

--- a/development.html
+++ b/development.html
@@ -17,7 +17,7 @@ There are several ways to get into development:
 </p>
 
 <ul>
-  <li><strong>Modding:</strong> Develop a mod independently and publish it on the <a href="http://forum.minetest.net/">forums</a>.</li>
+  <li><strong>Modding:</strong> Develop a mod independently and publish it on the <a href="https://forum.minetest.net/">forums</a>.</li>
   <li><strong>Core development:</strong> Think or ask of something that is needed in the core, talk with the core team (preferably a lot, with multiple members - communication is more important than you think) and do it.</li>
   <li><strong>Translating:</strong> Help translating Minetest at <a href="https://hosted.weblate.org/projects/minetest/minetest/">our web interface</a>. If your language does not exist yet, contact a core dev.</li>
 </ul>
@@ -44,18 +44,18 @@ Minetest is distributed as an engine, combined with a couple of games. Upstream 
 <ul>
 <li><div> <strong>The engine</strong> (core) is the base for everything. C++ is used for housekeeping and performance-critical stuff, Lua for extensible things.</div>
 </li>
-<li><div> <strong>Games</strong> define game content: nodes, entities, textures, meshes, sounds and custom behavior implemented in Lua. Games consist of mods that plug into the engine using the <a href="http://dev.minetest.net">Modding API</a>.</div>
+<li><div> <strong>Games</strong> define game content: nodes, entities, textures, meshes, sounds and custom behavior implemented in Lua. Games consist of mods that plug into the engine using the <a href="//dev.minetest.net">Modding API</a>.</div>
 </li>
 </ul>
 
 <p>
-  For more information see the <a href="http://dev.minetest.net/Terminology">terminology</a> or <a href="http://dev.minetest.net/Engine_structure">engine structure</a> developer wiki pages.
+  For more information see the <a href="//dev.minetest.net/Terminology">terminology</a> or <a href="//dev.minetest.net/Engine_structure">engine structure</a> developer wiki pages.
 </p>
 
 <h2>Rules</h2>
 
 <p>
-<a href="http://dev.minetest.net/All_rules_regarding_to_development">All rules regarding to development</a>
+<a href="//dev.minetest.net/All_rules_regarding_to_development">All rules regarding to development</a>
 </p>
 
 <h1 id="reporting-issues">Reporting issues</h1>
@@ -173,7 +173,7 @@ Minetest is distributed as an engine, combined with a couple of games. Upstream 
 </p>
 
 <p>
-  Profits are used as donations for something related to Minetest. <a href="http://forum.minetest.net/viewtopic.php?t=4437" title="http://forum.minetest.net/viewtopic.php?t=4437">Forum thread</a>.
+  Profits are used as donations for something related to Minetest. <a href="https://forum.minetest.net/viewtopic.php?t=4437" title="https://forum.minetest.net/viewtopic.php?t=4437">Forum thread</a>.
 </p>
 
 <br>

--- a/downloads.html
+++ b/downloads.html
@@ -18,11 +18,11 @@ redirect_from:
 
 <p class="intro">
   You may also want to look at some <a href="https://forum.minetest.net/viewforum.php?f=15">subgames</a>. Subgames form a foundation for the game using Lua scripts. Different subgames have different objectives, such as survival, building or Player vs Player.
-  Usually Minetest comes with <a href="https://github.com/minetest/minetest_game">Minetest Game</a>, to supply the default items and blocks. You can then add <a href="http://minetest.net/customize/#mods">mods</a> on top of a subgame in order to customize your experience further.
+  Usually Minetest comes with <a href="https://github.com/minetest/minetest_game">Minetest Game</a>, to supply the default items and blocks. You can then add <a href="/customize/#mods">mods</a> on top of a subgame in order to customize your experience further.
 </p>
 
 <p class="intro">
-  <a href="http://dev.minetest.net/Changelog#0.4.12_.E2.86.92_0.4.13">Changelog from 0.4.12 to 0.4.13</a>
+  <a href="//dev.minetest.net/Changelog#0.4.12_.E2.86.92_0.4.13">Changelog from 0.4.12 to 0.4.13</a>
 </p>
 
 <div class="line"></div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ redirect_from:
   <div class="row">
     <div class="col-lg-4">
       <h4>Modding API</h4>
-      <p><a href="http://dev.minetest.net/Intro">Modify the game and add new content</a> using the <a href="//www.lua.org/">Lua</a> programming language.</p>
+      <p><a href="//dev.minetest.net/Intro">Modify the game and add new content</a> using the <a href="http://www.lua.org/">Lua</a> programming language.</p>
     </div>
     <div class="col-lg-4">
       <h4>Texture packs</h4>

--- a/servers.html
+++ b/servers.html
@@ -7,21 +7,21 @@ redirect_from:
 
 <br>
 <p>
-  <strong>The server list is also available at <a href="http://servers.minetest.net/" title="http://servers.minetest.net/" rel="nofollow">servers.minetest.net/</a>.</strong>
+  <strong>The server list is also available at <a href="//servers.minetest.net/" title="//servers.minetest.net/" rel="nofollow">servers.minetest.net/</a>.</strong>
 </p>
 <br>
 
 <p>
   <div id="server_list"></div>
-  <link rel="stylesheet" href="http://servers.minetest.net/style.css"/>
-  <script>var master = {root: 'http://servers.minetest.net/', no_avgtop:1, no_ping:1, no_uptime:1, limit:10, clients_min:1};</script>
-  <script src="http://servers.minetest.net/list.js"></script>
+  <link rel="stylesheet" href="//servers.minetest.net/style.css"/>
+  <script>var master = {root: '//servers.minetest.net/', no_avgtop:1, no_ping:1, no_uptime:1, limit:10, clients_min:1};</script>
+  <script src="//servers.minetest.net/list.js"></script>
 </p>
 <p>
   <div id="server_list"></div>
-  <link rel="stylesheet" href="http://servers.minetest.net/style.css"/>
-  <script>var master = {root: 'http://servers.minetest.net/', no_avgtop:1, no_ping:1, no_uptime:1, limit:10, clients_min:1};</script>
-  <script src="http://servers.minetest.net/list.js"></script>
+  <link rel="stylesheet" href="//servers.minetest.net/style.css"/>
+  <script>var master = {root: '//servers.minetest.net/', no_avgtop:1, no_ping:1, no_uptime:1, limit:10, clients_min:1};</script>
+  <script src="//servers.minetest.net/list.js"></script>
 </p>
 
 <h2 id="flags">Flags</h2>


### PR DESCRIPTION
Internal links should go over the protocol the website is currently surfed with.

Before merging, all of `minetest.net` subdomains should support https. That is:
- {forum,wiki,dev,www}.minetest.net hosted by celeron55
- minetest.net hosted by celeron55 
- servers.minetest.net hosted by sfan5 (does now)
- inchra-stats.minetest.net hosted by ShadowNinja 

Otherwise it could lead to issues if minetest.net supports https, and other sites don't.
Currently, there is only dependency on `inchra-stats.minetest.net`. This PR doesn't make the dependency more serious.

Also, the link in the README.md got changed to https.
Fixes #47.
