### PR TITLE
Remove "unofficial" from homebrew

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -63,7 +63,7 @@ redirect_from:
 
 <ul>
   <li><a href="https://forum.minetest.net/viewtopic.php?t=9190">Stable OS X builds</a></li>
-  <li>Using <a href="http://brew.sh/">Homebrew</a>? <code>brew install homebrew/games/minetest</code> <em>(unofficial)</em></li>
+  <li>Using <a href="http://brew.sh/">Homebrew</a>? <code>brew install homebrew/games/minetest</code></li>
 </ul>
 
 <div class="line"></div>


### PR DESCRIPTION
If homebrew way is unofficial, then downloading binary from forum/github is unofficial as well