### PR TITLE
Add alt text to images in the main gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,37 +62,37 @@ redirect_from:
   <div class="row">
     <div class="col-lg-6">
       <a href="/media/gallery/1.jpg" class="thumbnail">
-        <img src="/media/gallery/1-thumb.jpg">
+        <img src="/media/gallery/1-thumb.jpg" alt="A sandy beach with grass and trees in the distance">
       </a>
     </div>
 
     <div class="col-lg-6">
       <a href="/media/gallery/2.jpg" class="thumbnail">
-        <img src="/media/gallery/2-thumb.jpg">
+        <img src="/media/gallery/2-thumb.jpg" alt="A grassy field with rock and trees">
       </a>
     </div>
 
     <div class="col-lg-6">
       <a href="/media/gallery/3.jpg" class="thumbnail">
-        <img src="/media/gallery/3-thumb.jpg">
+        <img src="/media/gallery/3-thumb.jpg" alt="A pond with papyrus">
       </a>
     </div>
 
     <div class="col-lg-6">
       <a href="/media/gallery/4.jpg" class="thumbnail">
-        <img src="/media/gallery/4-thumb.jpg">
+        <img src="/media/gallery/4-thumb.jpg" alt="A jungle with trees and grass">
       </a>
     </div>
 
     <div class="col-lg-6">
       <a href="/media/gallery/5.jpg" class="thumbnail">
-        <img src="/media/gallery/5-thumb.jpg">
+        <img src="/media/gallery/5-thumb.jpg" alt="A cave lit with torches">
       </a>
     </div>
 
     <div class="col-lg-6">
       <a href="/media/gallery/6.jpg" class="thumbnail">
-        <img src="/media/gallery/6-thumb.jpg">
+        <img src="/media/gallery/6-thumb.jpg" alt="A cave filled with lava">
       </a>
     </div>
   </div>


### PR DESCRIPTION
Add alt text describing the images that are in the gallery on the main page of the website.

This helps to make the page more accessible to things like screen readers.