### PR TITLE
Add automated HTML tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site/
 node_modules/
 .jekyll-metadata
 *.patch
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 2.2
+sudo: false
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproofer '_site/' --allow-hash-href --check-html
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'jekyll-redirect-from'
+gem 'html-proofer'


### PR DESCRIPTION
This adds some automated tests of the generated website HTML using Travis CI.

The tests include checks for valid HTML, valid links, and alt attributes on images and links. If some of these tests are not wanted, they can be disabled by using different flags for `html-proofer`

Currently, the tests fail due to a  few pre-existing issues, mainly links without alt attributes and some unneeded p tags. However, once those issues are fixed the tests should pass.

https://travis-ci.org/ExcaliburZero/minetest.github.io/builds/155429185