### PR TITLE
Update Ruby version for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.2.2
 sudo: false
 script:
   - bundle exec jekyll build


### PR DESCRIPTION
Update the version of Ruby used in Travis CI builds to fix dependency issues.

Closes #74 

----

Also, note that while this fixes the dependencies issues in the build, it does not fix the existing issues in the website found by html-proofer. See #70 for more info.

----

**Example Build:** https://travis-ci.org/ExcaliburZero/minetest.github.io/builds/166568992