### PR TITLE
Update list of mods / texture packs on Customize page

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -49,7 +49,6 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   <div class="col-sm-6">
     <h3>Building</h3>
     <ul>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=9019">Farming Redo</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=2041">Home Decor</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=12534">X-Decor</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=509">More Blocks</a></li>
@@ -84,8 +83,9 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   </div>
 
   <div class="col-sm-6">
-    <h3>Mobs</h3>
+    <h3>Plants & Mobs</h3>
     <ul>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=9019">Farming Redo</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=629">Animals Modpack</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=8638">Creatures Mob Engine</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=9917">Mobs Redo</a></li>
@@ -109,6 +109,7 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4877">Travelnet teleporters</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4086">UFOs</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=14726">Advanced Trains</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=13988">Cars</a></li>
     </ul>
   </div>
 </div>
@@ -129,8 +130,8 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   <div class="col-sm-6">
     <h3>Inventory</h3>
     <ul>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=5641">Crafting</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=2334">Craft Guide</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=5641">Crafting</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=6204">Inventory++</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=3933">Unified Inventory</a></li>
     </ul>

--- a/customize.html
+++ b/customize.html
@@ -49,12 +49,14 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   <div class="col-sm-6">
     <h3>Building</h3>
     <ul>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=2787">Farming Plus</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=9019">Farming Redo</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=2041">Home Decor</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=12534">X-Decor</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=509">More Blocks</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=5682">Quartz</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=2984">Streets</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=6099">Torches</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=15651">Colored Clay</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=638">Nuke</a></li>
     </ul>
   </div>
 
@@ -86,7 +88,7 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
     <ul>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=629">Animals Modpack</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=8638">Creatures Mob Engine</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=3063">Simple Mobs</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=9917">Mobs Redo</a></li>
     </ul>
   </div>
 </div>
@@ -104,9 +106,9 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   <div class="col-sm-6">
     <h3>Transport</h3>
     <ul>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=2451">Carts</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4877">Travelnet teleporters</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4086">UFOs</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14726">Advanced Trains</a></li>
     </ul>
   </div>
 </div>
@@ -118,8 +120,9 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4654">3D Armor</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=4870">Achievements</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=6342">Better HUD (and hunger)</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=2656">Minecraft-like item drop/pick-up</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=2805">Throwing</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14006">Minecraft-like item drop/pick-up</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=11437">Throwing Enhanced</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14384">Bows</a></li>
     </ul>
   </div>
 
@@ -136,7 +139,7 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
 
 <div class="row">
   <div class="col-sm-6">
-    <h3>Maintainance</h3>
+    <h3>Maintenance</h3>
     <ul>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=7239">Advanced area protection</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=572">WorldEdit</a></li>
@@ -161,12 +164,15 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
     <ul>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=9564">PureBDTest</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=1583">HDX Textures</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=4990">PixelBOX</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14132">PixelBOX Reloaded</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14289">PixelPerfection</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=9314">Summerfields</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=15758">Vanilla 32x32</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=14633">mini8x</a></li>
     </ul>
   </div>
 </div>
 
 <p>
   Find more <a href="https://forum.minetest.net/viewforum.php?f=4">texture packs</a> on the forums.
-  <!-- TODO: Make a gallery of popular packs -->
 </p>

--- a/customize.html
+++ b/customize.html
@@ -83,7 +83,7 @@ More subgames are available <a href="https://forum.minetest.net/viewforum.php?f=
   </div>
 
   <div class="col-sm-6">
-    <h3>Plants & Mobs</h3>
+    <h3>Plants &amp; Mobs</h3>
     <ul>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=9019">Farming Redo</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=629">Animals Modpack</a></li>


### PR DESCRIPTION
**removed:**
* farming_plus: not updated since >2 years
* torches: built into minetest_game
* simple mobs: not updated since >3 years
* carts: built into minetest_game
* throwing: not updated since >3 years
* item_drop: not updated since >3 years
* PixelBOX: no longer updated

**added:**
* farming redo: substitute for farming_plus
* mobs redo: substitute for simple mobs
* throwing enhanced: substitute for throwing
* item_drop (jordan4ibanez): substitute for the old item_drop
* PixelBOX Reloaded: substitute for pixelbox
* mods/texture packs from here: https://github.com/minetest/minetest.github.io/issues/76#issuecomment-260747701