### PR TITLE
Update homebrew install command

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -53,7 +53,7 @@ redirect_from:
 <p>OS X 10.10 or later is recommended.</p>
 
 <ul>
-  <li>Use <a href="http://brew.sh/">Homebrew</a> to get stable version <code>brew install homebrew/games/minetest</code></li>
+  <li>Use <a href="http://brew.sh/">Homebrew</a> to get stable version <code>brew install minetest</code></li>
   <li><a href="https://forum.minetest.net/viewtopic.php?t=9190">Daily unstable builds</a></li>
 </ul>
 


### PR DESCRIPTION
homebrew/games/ is now deprecated. "brew install minetest" should now be used