### PR TITLE
Minetest is available for OpenBSD too!

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -9,7 +9,7 @@
       or play on a multiplayer server.
     </p>
     <p>
-      Available for Windows, macOS, GNU/Linux, FreeBSD, and Android.
+      Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, and Android.
     </p>
     <p><a class="btn btn-primary btn-lg" href="#features">Tell me more</a> <a class="btn btn-success btn-lg" href="/downloads/">Download</a></p>
     <p><small><strong>News:</strong> 0.4.17 released. (June 3<sup>rd</sup> 2018)</small></p>


### PR DESCRIPTION
https://marc.info/?l=openbsd-ports&m=152811824915609&w=2

I don't think it is necessary to tell how to download/install this game at OpenBSD, but anyway I'm not familiar with HTML to edit downloads page:

OpenBSD

Package manager

You can use official pre-built package:
```
# pkg_add minetest
```

Compile using ports

You can compile Minetest using OpenBSD ports tree:
```
$ cd /usr/ports/games/minetest
# make -j `sysctl -n hw.ncpu` install
```