### PR TITLE
Add Matrix Chat to Community Dropdown

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -87,6 +87,7 @@
                    <li><a href="/community/">Overview</a></li>
                    <li><a href="https://forum.minetest.net">Forum ↗</a></li>
                    <li><a href="//wiki.minetest.net">Wiki ↗</a></li>
+                   <li><a href="https://matrix.to/#/!OOyNJWoeFncyeWzxVh:matrix.org">Unofficial Matrix</a></li>
                    <li><a href="/irc/">IRC</a></li>
                    <li><a href="https://reddit.com/r/minetest">Subreddit ↗</a></li>
                    <li><a href="/credits/">Contributors</a></li>


### PR DESCRIPTION
I spread the notion to add the Unofficial Minetest Riot/Matrix Chat to the Minetest.net Website. 

Part of issue: #136 

Dear Maintainers, feel free to make edits to this pull request.