### PR TITLE
Fix Webchat usability on #minetest-dev

### DIFF
--- a/irc.html
+++ b/irc.html
@@ -10,7 +10,7 @@ redirect_from:
 <div>
   <p>
     Join one of our <abbr title="Internet Relay Chat">IRC</abbr> channels on Freenode:<br/>
-    To chat on #minetest-hub you need to ask an operator for voice. Webchat cannot be used on #minetest-dev.<br>
+    To chat on #minetest-hub you need to ask an operator for voice. Webchat can be used to listen only, not talk, on #minetest-dev.<br>
   </p>
   <ul>
     <li>


### PR DESCRIPTION
Webchat is able to connect to #minetest-dev, just not send messages to it. So says [the wiki](https://wiki.minetest.net/IRC), and this seems to agree with an experiment. Fix the IRC page accordingly.