### PR TITLE
Changing recomended texture packs

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -156,11 +156,12 @@ redirect_from:
   <div class="col-sm-6">
     <h3>Popular Texture Packs</h3>
     <ul>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=9564">PureBDTest</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=1583">HDX Textures</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=14132">PixelBOX Reloaded</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=14289">PixelPerfection</a></li>
-      <li><a href="https://forum.minetest.net/viewtopic.php?t=15758">Vanilla 32x32</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=21523">Isabella II</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=16027">Good Morning Craft</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=19881">Vilja Pix</a></li>
+      <li><a href="https://forum.minetest.net/viewtopic.php?t=1583">HDX Textures</a></li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=14633">mini8x</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Removed PureBDTest, The license doesn't allow for a download, therefore we shouldn't link to this.
Rearranged putting nice looking 16px first.
Removed Vanilla 32x32, GitHub link is dead.
Added Good Morning Craft.
Added Vilja Pix.