### PR TITLE
Now Minetest runs at DragonFly BSD

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -9,7 +9,7 @@
       or play on a multiplayer server.
     </p>
     <p>
-      Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, and Android.
+      Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, DragonFly BSD, and Android.
     </p>
     <p><a class="btn btn-primary btn-lg" href="#features">Tell me more</a> <a class="btn btn-success btn-lg" href="/downloads/">Download</a></p>
     <p><small><strong>News:</strong> 0.4.17.1 released. (June 10<sup>th</sup> 2018)</small></p>


### PR DESCRIPTION
Hi! I am an active [Ravenports](http://www.ravenports.com/) contributor and today I made Minetest 0.4.17.1 run at DragonFly BSD: https://github.com/jrmarino/ravensource/tree/master/bucket_14/minetest https://github.com/DragonFlyBSD/DeltaPorts/pull/892