### PR TITLE
Fix deprecated `gems` entry in configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,10 @@
 permalink: pretty
-gems:
+plugins:
   - jekyll-redirect-from
 sass:
   style: compressed
 exclude:
   - CNAME
-  - README.md
+  - Gemfile
   - LICENSE.md
+  - README.md


### PR DESCRIPTION
This addresses this warning which appears with recent Jekyll versions:

```text
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```

This also excludes `Gemfile` as it doesn't need to be included in the generated website.