### PR TITLE
Remove old 0.4 references.

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -17,7 +17,7 @@ redirect_from:
   Have a look at our <a href="//wiki.minetest.net/Getting_Started">Getting Started</a>,
   <a href="//wiki.minetest.net/FAQ">FAQ</a>,
    and <a href="//wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
-  Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#0.4.17_.E2.86.92_0.4.17.1">changelog</a>.
+  Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#0.4.16_.E2.86.92_5.0.0">changelog</a>.
 </p>
 
 <p>
@@ -144,7 +144,7 @@ make install</pre>
   <div class="col-sm-6">
     <h2>Source code</h2>
 
-    <p>Get the latest <a href="https://github.com/minetest/minetest/tree/stable-0.4">stable</a>
+    <p>Get the latest <a href="https://github.com/minetest/minetest/tree/stable-5">stable</a>
     or <a href="https://github.com/minetest/minetest">development</a> source code from
     <a href="https://github.com/minetest/minetest">GitHub</a>.<br>
     You will probably want <a href="https://github.com/minetest/minetest_game">minetest_game</a> as well.


### PR DESCRIPTION
There are/were still some Minetest 0.4.17.1 references left in /downloads.