### PR TITLE
add the MacPorts MT port

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -140,6 +140,9 @@ make install</pre>
 
     <ul>
       <li>Use <a href="https://brew.sh/">Homebrew</a> to get the stable version: <code>brew install minetest</code></li>
+      <li>Use <a href="https://www.macports.org/">MacPorts</a> to get the stable version: <code>sudo port install minetest</code>. 
+	   You may refer to <a href="https://forum.minetest.net/viewtopic.php?f=42&t=22427">[macOS & MacPorts]</a> 
+	   in the forum for further information.</li>
       <li><a href="https://forum.minetest.net/viewtopic.php?t=9190">Daily unstable builds</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Please consider to add **MacPorts** to get the stable version: "sudo port install minetest" on the MT download page. This is an additional option and may be an alternative to Homebrew and the daily builds.

For background information please refer to my contribiton [macOS & MacPorts](https://forum.minetest.net/viewtopic.php?f=42&t=22427) in the forum.

Thanks in advance.