### PR TITLE
Lua API Link pointed a domain without valild SSL Cert

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,7 +42,7 @@
             <li><a href="https://github.com/minetest/minetest">Github</a></li>
             <li><a href="/get_involved/#internet-relay-chat">#minetest-dev on Freenode IRC</a></li>
             <li><a href="https://dev.minetest.net">Developer Wiki</a></li>
-            <li><a href="https://minetest.net/lua_api/">Lua API</a></li>
+            <li><a href="https://www.minetest.net/lua_api/">Lua API</a></li>
             <li><a href="/get_involved/#donate">Donate</a></li>
           </ul>
         </div>


### PR DESCRIPTION
There is no SSL Cert for minetest.net without subdomain www why the  link resulted in a invalid cert browser error