### PR TITLE
Fix a comment being displayed on the downloads page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -75,10 +75,10 @@ redirect_from:
         <p>
           Alternatively, install from
           <a href="https://f-droid.org/en/packages/net.minetest.minetest/">F-Droid</a>.
-          {#
+          {% comment %}
           or
           <a href="https://github.com/minetest/minetest/releases/download/5.0.1/Minetest-5.0.1.24.apk">download the APK</a>.
-          #}
+          {% endcomment %}
         </p>
         <p>
           <strong>Note:</strong> We advise not to use unofficial builds commonly found on the Play Store.


### PR DESCRIPTION
Liquid comments use `{% comment %}` tags, not `{# #}`.