### PR TITLE
Add a fallback color for the background image

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -1,6 +1,9 @@
 // Used for the "hero" header on the homepage
 .section-home {
   background-image: url("/media/background-home.jpg");
+  // Background color is displayed while the image is loading,
+  // so that the text is still readable
+  background-color: hsl(0, 1%, 13%);
   font-size: $size-5;
   text-align: center;
 


### PR DESCRIPTION
The color is displayed while the image is loading. This way, text is still readable if the image takes a while to load (which can be the case on a slow connection).