### PR TITLE
Enable strict front matter in Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ exclude:
   - LICENSE.md
   - README.md
 
+strict_front_matter: true
+
 liquid:
   error_mode: strict
   strict_filters: true


### PR DESCRIPTION
This causes invalid YAML in front matter to result in an build error instead of just printing a warning. This can be used to catch potential mistakes quicker.