### PR TITLE
Link to HTTPS resources when available, use `relative_url` consistently

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,11 +5,11 @@
       <div class="column is-6 is-3-desktop">
         <h5 class="footer-title">Minetest</h5>
         <ul class="list-unstyled">
-          <li><a href="/#features">Features</a></li>
-          <li><a href="/#gallery">Gallery</a></li>
-          <li><a href="/downloads/">Downloads</a></li>
+          <li><a href="{{ '/#features' | relative_url }}">Features</a></li>
+          <li><a href="{{ '/#gallery' | relative_url }}">Gallery</a></li>
+          <li><a href="{{ '/downloads/' | relative_url }}">Downloads</a></li>
           <li><a href="https://forum.minetest.net/viewforum.php?f=18">News</a></li>
-          <li><a href="/credits/">Credits</a></li>
+          <li><a href="{{ '/credits/' | relative_url }}">Credits</a></li>
         </ul>
       </div>
 
@@ -17,7 +17,7 @@
         <h5 class="footer-title">Content</h5>
         <ul class="list-unstyled">
           <li><a href="https://content.minetest.net">ContentDB</a></li>
-          <li><a href="/customize/#featured">Featured</a></li>
+          <li><a href="{{ '/customize/#featured' | relative_url }}">Featured</a></li>
           <li><a href="https://content.minetest.net/packages/?type=game">Games</a></li>
           <li><a href="https://content.minetest.net/packages/?type=mod">Mods</a></li>
           <li><a href="https://content.minetest.net/packages/?type=txp">Texture Packs</a></li>
@@ -29,7 +29,7 @@
         <ul class="list-unstyled">
           <li><a href="https://forum.minetest.net">Forums</a></li>
           <li><a href="https://wiki.minetest.net/IRC">IRC</a></li>
-          <li><a href="/servers/">Servers</a></li>
+          <li><a href="{{ '/servers/' | relative_url }}">Servers</a></li>
           <li><a href="https://wiki.minetest.net">Player Wiki</a></li>
           <li><a href="https://reddit.com/r/minetest/">Subreddit</a></li>
         </ul>
@@ -42,7 +42,7 @@
           <li><a href="https://wiki.minetest.net/IRC">#minetest-dev on Freenode IRC</a></li>
           <li><a href="https://dev.minetest.net">Developer Wiki</a></li>
           <li><a href="https://minetest.gitlab.io/minetest/">Lua API</a></li>
-          <li><a href="/get-involved/#donate">Donate</a></li>
+          <li><a href="{{ '/get-involved/#donate' | relative_url }}">Donate</a></li>
         </ul>
       </div>
 

--- a/customize.html
+++ b/customize.html
@@ -28,7 +28,7 @@ redirect_from:
       <h3 id="games">Games</h3>
       <p>
         The Minetest Engine runs games.
-        Different <a href="http://wiki.minetest.net/Games">games</a> have different objectives –
+        Different <a href="https://wiki.minetest.net/Games">games</a> have different objectives –
         such as survival,  building, or player vs. player. Usually Minetest comes with
         <a href="https://github.com/minetest/minetest_game">Minetest Game</a>,
         which supplies the default items.
@@ -36,7 +36,7 @@ redirect_from:
 
       <ul>
         <li><a href="https://forum.minetest.net/viewtopic.php?t=6346">Voxelgarden</a> - Survival and progression. Focus is on quality over features.</li>
-        <li><a href="http://wiki.minetest.net/Games/Tutorial">Tutorial</a> - Teaches the fundamental basics of Minetest.</li>
+        <li><a href="https://wiki.minetest.net/Games/Tutorial">Tutorial</a> - Teaches the fundamental basics of Minetest.</li>
         <li><a href="https://forum.minetest.net/viewtopic.php?t=13181">Pixture</a> - Small game which aims to be playable without any mods.</li>
         <li><a href="https://forum.minetest.net/viewtopic.php?t=13761">rpgtest</a> - Classic RPG-like gameplay.</li>
       </ul>
@@ -50,7 +50,7 @@ redirect_from:
       <h3 id="mods">Mods</h3>
       <p>
         Minetest is meant to be modded. Mods can add or change functionality and content.
-        Learn how to <a href="http://dev.minetest.net/Installing_Mods">install and use mods</a>.
+        Learn how to <a href="https://dev.minetest.net/Installing_Mods">install and use mods</a>.
       </p>
 
       <div class="columns is-multiline">

--- a/downloads.html
+++ b/downloads.html
@@ -17,9 +17,9 @@ redirect_from:
     <h2>Getting started</h2>
     <p>
       Are you a new user?
-      Have a look at our <a href="//wiki.minetest.net/Getting_Started">Getting Started</a>,
-      <a href="//wiki.minetest.net/FAQ">FAQ</a>,
-       and <a href="//wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
+      Have a look at our <a href="https://wiki.minetest.net/Getting_Started">Getting Started</a>,
+      <a href="https://wiki.minetest.net/FAQ">FAQ</a>,
+       and <a href="https://wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
       Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#5.1.0_.E2.86.92_5.2.0">changelog</a>.
     </p>
     <p>
@@ -30,7 +30,7 @@ redirect_from:
       Usually Minetest comes with
       <a href="https://github.com/minetest/minetest_game">Minetest Game</a>,
       to supply the default items and blocks.
-      You can then add <a href="http://minetest.net/customize/#mods">mods</a> on
+      You can then add <a href="{{ '/customize/#mods' | relative_url }}">mods</a> on
       top of a game in order to customize your experience further.
     </p>
 
@@ -56,7 +56,7 @@ redirect_from:
         </ul>
         <p>
           Stuck? See
-          <a href="//wiki.minetest.net/Getting_Started#Windows">help on getting Minetest on Windows.</a>
+          <a href="https://wiki.minetest.net/Getting_Started#Windows">help on getting Minetest on Windows.</a>
         </p>
         <p>
           You can also get the latest development version of Minetest from

--- a/get-involved.html
+++ b/get-involved.html
@@ -20,7 +20,7 @@ redirect_from:
       {% for link in site.data.community %}
       <a class="column has-text-centered no-underline hover-enlarge" href="{{ link.url }}">
         <div class="image">
-          <img src="/media/logos/{{ link.icon }}" alt="{{ link.name }} logo">
+          <img src="{{ '/media/logos/' | append: link.icon | relative_url }}" alt="{{ link.name }} logo">
         </div>
         <span class="title">{{ link.name }}</span>
       </a>
@@ -38,7 +38,7 @@ redirect_from:
         <div class="content">
           <ul>
             <li>
-              Work on a <a href="http://dev.minetest.net/Modding_Intro">game or mod</a>,
+              Work on a <a href="https://dev.minetest.net/Modding_Intro">game or mod</a>,
               and publish it on <a href="https://content.minetest.net">ContentDB</a>
               or <a href="https://forum.minetest.net">the forums</a>.
             </li>
@@ -100,7 +100,7 @@ redirect_from:
         Upstream repositories and official Windows packages are handled by the
         <a href="https://github.com/minetest?tab=members">core team</a>,
         consisting of a bunch of people who are much trusted to keep Minetest progressing in good condition.
-        The core team is formed of people who have made great <a href="/credits/">contributions</a> to Minetest.
+        The core team is formed of people who have made great <a href="{{ '/credits/' | relative_url }}">contributions</a> to Minetest.
         Contributions are approved if two members of the core team agree on them.
       </p>
       <p>
@@ -108,7 +108,7 @@ redirect_from:
       </p>
       <p>
         For more information, take a look at
-        <a href="http://dev.minetest.net/All_rules_regarding_to_development">
+        <a href="https://dev.minetest.net/All_rules_regarding_to_development">
           all the rules regarding to development
         </a>.
       </p>
@@ -130,14 +130,14 @@ redirect_from:
           <strong>Games</strong> define game content: nodes, entities,
           textures, meshes, sounds and custom behavior implemented in Lua.
           Games consist of mods that plug into the engine using the
-          <a href="http://dev.minetest.net">Modding API</a>.
+          <a href="https://dev.minetest.net">Modding API</a>.
         </li>
       </ul>
 
       <p>
         For more information see the
-        <a href="http://dev.minetest.net/Terminology">terminology</a> or
-        <a href="http://dev.minetest.net/Engine_structure">engine structure</a>
+        <a href="https://dev.minetest.net/Terminology">terminology</a> or
+        <a href="https://dev.minetest.net/Engine_structure">engine structure</a>
         developer wiki pages.
       </p>
     </div>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ redirect_from:
         </p>
         <div class="home-buttons">
           <a class="button is-info is-size-5" href="#features">Tell me more</a>
-          <a class="button is-primary is-size-5" href="/downloads/">Download</a>
+          <a class="button is-primary is-size-5" href="{{ '/downloads/' | relative_url }}">Download</a>
         </div>
         <p class="is-size-6">
           <span class="has-text-weight-bold">News:</span> 5.2.0 released. (April 5<sup>th</sup> 2020)


### PR DESCRIPTION
This makes internal anchors still work if the site's base URL ever changes.