### PR TITLE
Add a forum redirection page

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,6 +5,17 @@ layout: default
 permalink: 404.html
 ---
 
+<script>
+  // Forum URL redirection
+  const urlParams = new URLSearchParams(window.location.search.slice(1));
+
+  if (urlParams.has('id')) {
+    // Convert to a number for security (only numeric values make sense anyway)
+    const topicId = Number(urlParams.get('id'));
+    window.location.replace(`https://forum.minetest.net/viewtopic.php?id=${topicId}`);
+  }
+</script>
+
 <section class="section">
   <div class="container">
     <div class="content">


### PR DESCRIPTION
This is done in the 404 error page as it will match any invalid URL, including `/forum/viewtopic.php`. We can't create a page with a custom permalink set to `/forum/viewtopic.php`, as GitHub Pages doesn't set the MIME type correctly, which causes the browser to download the page.

This closes #187.