### PR TITLE
Fix spelling error

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,7 +38,7 @@
       <div class="column is-6 is-3-desktop">
         <h5 class="footer-title">Development</h5>
         <ul class="list-unstyled">
-          <li><a href="https://github.com/minetest/minetest">Github</a></li>
+          <li><a href="https://github.com/minetest/minetest">GitHub</a></li>
           <li><a href="https://wiki.minetest.net/IRC">#minetest-dev on Freenode IRC</a></li>
           <li><a href="https://dev.minetest.net">Developer Wiki</a></li>
           <li><a href="https://minetest.gitlab.io/minetest/">Lua API</a></li>


### PR DESCRIPTION
`GitHub` wasn't spelled correctly.
Before:

    Github

After:

    GitHub