### PR TITLE
Add the Snap to the Linux downloads page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -92,8 +92,10 @@ redirect_from:
         <p>Those may be out of date at times. If they are too out of date, you can build from source.</p>
 
         <ul>
-          <li>Flatpak (all distributions) -
+          <li class="has-text-weight-bold">Flatpak (all distributions) -
               <a href="https://flathub.org/apps/details/net.minetest.Minetest">Stable</a></li>
+          <li class="has-text-weight-bold">Snap (all distributions) -
+              <a href="https://snapcraft.io/minetest">Stable</a></li>
           <li>Debian -
               <a href="https://packages.debian.org/search?keywords=minetest">Stable</a></li>
           <li>Ubuntu -
@@ -112,7 +114,7 @@ redirect_from:
               <a href="https://aur.archlinux.org/packages/minetest-git-leveldb/">Unstable</a></li>
           <li>Gentoo -
               <a href="https://packages.gentoo.org/package/games-action/minetest">Stable</a></li>
-          <li>VoidLinux -
+          <li>Void Linux -
               <a href="https://github.com/void-linux/void-packages/tree/master/srcpkgs/minetest">Stable</a></li>
         </ul>
       </div>


### PR DESCRIPTION
- Bolden the Flatpak/Snap downloads since they're the most distribution-independent choices.
- Use the correct naming for Void Linux.

This closes #203.