### PR TITLE
Improve `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-*~
 _site/
 .sass-cache/
+.jekyll-cache/
+.bundle/
 node_modules/
+vendor/
 .jekyll-metadata
-*.patch
-vendor
-.bundle


### PR DESCRIPTION
- Add Jekyll 4's `jekyll-cache/` folder.
- Reorder to put directories first.
- Remove entries not specific to the project in question. For those entries, a global gitignore entry should be used on the user's system instead.