### PR TITLE
Update download link text to version 5.3.0

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -45,12 +45,12 @@ redirect_from:
         <ul>
           <li class="has-text-weight-bold">
             <a href="https://github.com/minetest/minetest/releases/download/5.3.0/minetest-5.3.0-win64.zip">
-              Minetest 5.2.0 - portable, 64-bit (recommended)
+              Minetest 5.3.0 - portable, 64-bit (recommended)
             </a>
           </li>
           <li>
             <a href="https://github.com/minetest/minetest/releases/download/5.3.0/minetest-5.3.0-win32.zip">
-              Minetest 5.2.0 - portable, 32-bit
+              Minetest 5.3.0 - portable, 32-bit
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Version description was outdated in the [Downloads](https://www.minetest.net/downloads/) page.
![image](https://user-images.githubusercontent.com/51391473/87206716-06207d00-c2d0-11ea-922b-59c13b4c1b6b.png)
