### PR TITLE
Change education mods link from wiki to ContentDB

### DIFF
--- a/_data/edu.yml
+++ b/_data/edu.yml
@@ -62,7 +62,7 @@ resources:
 - title: List of Mods for Education
   author: Various
   para: We have a large collection of educational mods, all of which are free and open source.
-  url: https://wiki.minetest.net/Mods:Learning
+  url: https://content.minetest.net/packages/?tag=education
 
 - title: Minetest Modding Book
   author: rubenwardy


### PR DESCRIPTION
This pull request changes the link from https://wiki.minetest.net/Mods:Learning to https://content.minetest.net/packages/?tag=education on the https://www.minetest.net/education/ page. This is due to the fact that the wiki page even says to go to contentdb itself.

also, topic was discussed with rubenwardy in UMTD(unofficial minetest discord)