### PR TITLE
Fixing a broken link to the Fedora RPM

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -104,7 +104,7 @@ redirect_from:
               <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/stable">Stable</a>,
               <a href="https://code.launchpad.net/~minetestdevs/+archive/daily-builds/+packages">Unstable</a></li>
           <li>Fedora -
-              <a href="https://apps.fedoraproject.org/packages/minetest">Stable</a></li>
+              <a href="https://src.fedoraproject.org/rpms/minetest">Stable</a></li>
           <li>openSUSE -
               <a href="https://software.opensuse.org/package/minetest">Stable</a></li>
           <li>Mageia -


### PR DESCRIPTION
visiting the link in the website ( from line number 107) is getting an error... using an alternative url for it