### PR TITLE
Update Discord invitation link

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -11,7 +11,7 @@
   icon: twitter.png
 
 - name: Discord
-  url: https://discord.gg/6W84ytH
+  url: https://discord.gg/minetest
   icon: discord.png
 
 - name: Reddit

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
           <li><a href="https://matrix.to/#/+minetest:tchncs.de">Matrix</a></li>
           <li><a href="https://fosstodon.org/@minetest" rel="me">Mastodon</a></li>
           <li><a href="https://twitter.com/MinetestProject">Twitter</a></li>
-          <li><a href="https://discord.gg/6W84ytH">Discord</a></li>
+          <li><a href="https://discord.gg/minetest">Discord</a></li>
           <li><a href="https://reddit.com/r/minetest/">Subreddit</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Things added/changed:

- Update Discord invitation link.
  - The Discord server has the [Vanity Invite URL](https://support.discord.com/hc/en-us/articles/115001542132-Server-Vanity-URLs) feature enabled; thus, the new invitation code/link is now `minetest`.
