### PR TITLE
GitHub Actions: Use the new way to toggle Bundler's deployment mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
     - name: Install dependencies
       run: |
        sudo apt-get install libcurl4-openssl-dev
-       bundle install --jobs=3 --retry=3 --deployment
+       bundle config set --local deployment 'true'
+       bundle install --jobs=3 --retry=3
     - name: Run tests
       run: |
        bundle exec jekyll build


### PR DESCRIPTION
This silences the following warning message:

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local deployment 'true'`, and stop using this flag
```