### PR TITLE
Add webrick as dependency in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Add wdm to avoid polling on Windows
 gem 'wdm' if Gem.win_platform?
 
-# Add webrick as dependencie because since Ruby 3.0.0 its not included anymore
+# webrick is not included in Ruby 3.0.0 and later, but it's required for the Jekyll development server.
 gem 'webrick'

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Add wdm to avoid polling on Windows
 gem 'wdm' if Gem.win_platform?
+
+# Add webrick as dependencie because since Ruby 3.0.0 its not included anymore
+gem 'webrick'


### PR DESCRIPTION
Hello,

Since Ruby 3.0.0 Webrick is not included in ruby anymore, so you have to install it.

Checkout my comment on this Pull request: https://github.com/slimphp/Slim-Website/pull/591#issuecomment-939287965