### PR TITLE
Update Matrix link

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,5 +1,5 @@
 - name: Matrix
-  url: https://matrix.to/#/+minetest:tchncs.de
+  url: https://matrix.to/#/#minetest:tchncs.de
   icon: matrix.png
 
 - name: Mastodon


### PR DESCRIPTION
"Communities" have been [deprecated](https://matrix.org/blog/2022/04/05/synapse-1-56-released#so-long-groups-and-thanks-for-all-the-fish) and are being replaced with spaces.