### PR TITLE
credits: Move Jude Melton-Houghton to previous core devs

### DIFF
--- a/_data/credits.yml
+++ b/_data/credits.yml
@@ -33,13 +33,13 @@ previous_core_devs: [
   "Aaron Suen",
   "paramat",
   "Pierre-Yves Rollo",
+  "Jude Melton-Houghton [Optimizations, bugfixes]",
 ]
 
 
 active_contributors: [
   "Wuzzy [Features, translations, devtest]",
   "Lars Müller [Lua optimizations and fixes]",
-  "Jude Melton-Houghton [Optimizations, bugfixes]",
   "paradust7 [Performance, fixes, Irrlicht refactoring]",
   "Desour [Fixes]",
   "ROllerozxa [Main menu]",


### PR DESCRIPTION
This was requested from me by someone who at a fair certainty is a relative of Jude Melton-Houghton (TurkeyMcMac).

Yes, it's a bit of an unusual skip from active contributors to previous core devs, but that's because this list was already lagging behind.