### PR TITLE
Change "open source" to "free software"

### DIFF
--- a/_data/features.yml
+++ b/_data/features.yml
@@ -46,7 +46,7 @@ developers:
 
     - title: Large Collection of Existing Mods
       description: >
-        There are over 1100 open source mods on
+        There are over 1100 free software mods on
         [ContentDB](https://content.minetest.net/),
         which are ready to be used, adapted or learned from.
 
@@ -54,8 +54,8 @@ developers:
       description: >
         You can find help with any problems [from our community](/get-involved/).
 
-    - title: Open Source
+    - title: Free Software
       description: >
-        The engine is open source and transparently developed.
+        The engine is free software, copyleft and transparently developed.
         [Submit an issue](https://github.com/minetest/minetest/issues)
         for anything you're missing, or get the source code and dig into it yourself.

--- a/get-involved.html
+++ b/get-involved.html
@@ -171,7 +171,7 @@ redirect_from:
 
       <h3 class="is-size-3">Roadmaps and Future Plans</h3>
       <p>
-        As an open source project developed by volunteers, Minetest is
+        As a free software project developed by volunteers, Minetest is
         mostly iteratively developed rather than formally planned. However,
         there are some overarching goals, both medium-term and long-term, that
         have been agreed upon by core developers:

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-title: Open source voxel game engine
+title: Free software voxel game engine
 layout: default
 homepage: true
 redirect_from:
@@ -12,7 +12,7 @@ redirect_from:
       <div class="column is-10 is-9-desktop is-8-widescreen is-7-fullhd">
         <h1 class="title">Minetest</h1>
         <p class="home-paragraph">
-          An open source voxel game engine.
+          A free software voxel game engine.
           Play one of our many games, mod a game to your liking, make your own game,
           or play on a multiplayer server.
         </p>


### PR DESCRIPTION
Considering the disinterested development of Minetest, with no real aim to enter the industry, I think it's more coherent to call it "free software" rather than "open source", a term born to not scare investors (since in English the word free also means "not costing anything"). I'd like to remember that the two terms refer to the same thing, what it changes is the perspective: ideological in the former, business oriented in the latter. I also think Minetest should set an example and that words do are important.

For an in-depth analysis: https://www.gnu.org/philosophy/open-source-misses-the-point.html

EDIT: build is failing, but it doesn't seem related to my changes