### PR TITLE
Add DevContainer configuration and add `.idea` folder to gitignore

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ruby Jekyll",
+  "image": "mcr.microsoft.com/devcontainers/jekyll:latest",
+  "forwardPorts": [4000]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site/
 node_modules/
 vendor/
 .jekyll-metadata
+.idea

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This site uses the [Jekyll](https://jekyllrb.com) static site generator.
 - Use `bundle exec jekyll serve` to automatically build the site
   and serve it locally.
 
+You can also use the provided [Dev Container](https://containers.dev/) configuration to make it easier.
+
 ### Browser support
 
 When working on new features, keep in mind this website only supports


### PR DESCRIPTION
## How to test?

Try the integration with any [supported editors](https://containers.dev/supporting).

With VSCode:

- Install VSCode
- Install and enable Dev Containers support: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
- Open the cloned repository in VSCode
- Notice the popup telling you about the presence of the dev container config file
- Click the reload editor button on the popup
- Wait until it downloads the base image and the VSCode server
- Open an integrated terminal (should be the container shell, not the host shell)
- Try to run `bundle exec jekyll serve`
- Notice the popup in VSCode asking you of opening the container served port in the browser