### PR TITLE
Add link to GitHub release page for older release

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -169,8 +169,13 @@ make install
           See the <a href="https://github.com/minetest/minetest/blob/master/README.md">README</a>
           for details on how to compile Minetest from source.
         </p>
-
-      </div>
+      </div>  
+    </div>
+    <div>
+      <hr>
+      <p>
+        Looking for older releases? Checkout the GitHub <a href="https://github.com/minetest/minetest/releases">release</a> page!
+      </p>
     </div>
   </div>
 </section>

--- a/downloads.html
+++ b/downloads.html
@@ -174,7 +174,7 @@ make install
     <div>
       <hr>
       <p>
-        Looking for older releases? Checkout the GitHub <a href="https://github.com/minetest/minetest/releases">release</a> page!
+        Looking for older versions? Check out the <a href="https://github.com/minetest/minetest/releases">list of releases</a> on GitHub!
       </p>
     </div>
   </div>


### PR DESCRIPTION
Fix #284 

![image](https://github.com/minetest/minetest.github.io/assets/61794590/cb570936-5dc6-4042-95cf-fc669d61bfa6)

If someone could review #286 btw that would be nice :) Its the only way that worked on my setup to build the website.