### PR TITLE
Don't recommend Debian repos anymore

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -103,9 +103,7 @@ redirect_from:
           <li>
             Debian - use
             <a href="https://flathub.org/apps/details/net.minetest.Minetest">Flatpak</a>
-            or compile from
-            <a href="https://github.com/minetest/minetest/tree/stable-5">source</a>,
-            as the repos are outdated
+            or compile from source, as the repos are outdated
           </li>
           <li>Arch Linux -
               <a href="https://archlinux.org/packages/?q=minetest">Stable</a>,

--- a/downloads.html
+++ b/downloads.html
@@ -99,7 +99,11 @@ redirect_from:
               <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/daily-builds">Daily PPA</a>
           </li>
           <li>Debian -
-              <a href="https://packages.debian.org/search?keywords=minetest">Stable</a></li>
+              use
+              <a href="https://flathub.org/apps/details/net.minetest.Minetest">Flatpak</a>
+              or compile from
+              <a href="https://github.com/minetest/minetest/tree/stable-5">source</a>,
+              as the repos are outdated</li>
           <li>Arch Linux -
               <a href="https://archlinux.org/packages/?q=minetest">Stable</a>,
               <a href="https://aur.archlinux.org/packages/minetest-git/">Unstable (AUR)</a></li>

--- a/downloads.html
+++ b/downloads.html
@@ -94,16 +94,19 @@ redirect_from:
               <a href="https://flathub.org/apps/details/net.minetest.Minetest">Stable</a></li>
           <!-- <li class="has-text-weight-bold">Snap (all distributions) -
               <a href="https://snapcraft.io/minetest">Stable</a></li> -->
-          <li>Ubuntu -
-              <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/stable">Stable PPA</a>,
-              <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/daily-builds">Daily PPA</a>
+          <li>
+            Ubuntu -
+            <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/stable">Stable PPA</a> or
+            <a href="https://launchpad.net/~minetestdevs/+archive/ubuntu/daily-builds">Daily PPA</a>,
+            as the repos are outdated
           </li>
-          <li>Debian -
-              use
-              <a href="https://flathub.org/apps/details/net.minetest.Minetest">Flatpak</a>
-              or compile from
-              <a href="https://github.com/minetest/minetest/tree/stable-5">source</a>,
-              as the repos are outdated</li>
+          <li>
+            Debian - use
+            <a href="https://flathub.org/apps/details/net.minetest.Minetest">Flatpak</a>
+            or compile from
+            <a href="https://github.com/minetest/minetest/tree/stable-5">source</a>,
+            as the repos are outdated
+          </li>
           <li>Arch Linux -
               <a href="https://archlinux.org/packages/?q=minetest">Stable</a>,
               <a href="https://aur.archlinux.org/packages/minetest-git/">Unstable (AUR)</a></li>


### PR DESCRIPTION
Alternatively, if Debian has something similar to a PPA then that would be good to mention there

![image](https://github.com/minetest/minetest.github.io/assets/2122943/8283aff8-5009-4cd1-a920-9a5e45efc532)
