### PR TITLE
Remove minetest_game note from FreeBSD section

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -127,13 +127,11 @@ redirect_from:
         <h2>FreeBSD</h2>
         <h3>Package manager</h3>
         <p>On FreeBSD 9.1 and newer, you can use the official pre-built packages:
-            <code>pkg install minetest minetest_game</code></p>
+            <code>pkg install minetest</code></p>
         <h3>Compile using ports</h3>
         <p>You can also compile Minetest and choose build options easily using the FreeBSD port dialogs.</p>
         <pre>
 cd /usr/ports/games/minetest
-make install
-cd /usr/ports/games/minetest_game
 make install
 </pre>
       </div>


### PR DESCRIPTION
This PR removes the hint to install `minetest_game` package in the FreeBSD section of the downloads page since Minetest is no longer shipped with minetest_game 