### PR TITLE
Initial rename of Minetest to Luanti

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# [Minetest Website](https://www.minetest.net)
+# [Luanti Website](https://www.minetest.net)
 
 [![Build status](https://github.com/minetest/minetest.github.io/workflows/build/badge.svg)](https://github.com/minetest/minetest.github.io/actions)\
-The official Minetest website, living at [www.minetest.net](https://www.minetest.net).
+The official Luanti website, living at [www.minetest.net](https://www.minetest.net).
 
 ## Features
 

--- a/_data/credits.json
+++ b/_data/credits.json
@@ -64,7 +64,7 @@
 		"superfloh247"
 	],
 	"previous_contributors": [
-		"Nils Dagsson Moskopp (erlehmann) <nils@dieweltistgarnichtso.net> [Minetest logo]",
+		"Nils Dagsson Moskopp (erlehmann) <nils@dieweltistgarnichtso.net> [Luanti logo]",
 		"red-001 <red-001@outlook.ie>",
 		"Giuseppe Bilotta",
 		"HybridDog",

--- a/_data/edu.yml
+++ b/_data/edu.yml
@@ -1,7 +1,7 @@
 why:
 - title: Free & Open Source
   para: >-
-    The Minetest Engine is [developed](/get-involved/) by an independent
+    The Luanti Engine is [developed](/get-involved/) by an independent
     community of [volunteer developers](/credits/). It is provided for
     everyone to use, modify, and redistribute freely.
 
@@ -14,7 +14,7 @@ why:
 
 - title: Low-spec & Cross-platform
   para: >-
-    Minetest has low system requirements, is compatible with previous
+    Luanti has low system requirements, is compatible with previous
     generations of hardware, and allows crossplay from any supported device.
 
 
@@ -48,7 +48,7 @@ projects:
     multiple rivers joining together.
   para: >-
     A project funded by the University of British Columbia around the use of
-    Minetest as a learning tool and for the production of digital twins of
+    Luanti as a learning tool and for the production of digital twins of
     natural and human built environments. It has been used to organize virtual
     field trips in the context of Covid 19.
   url: https://eml.ubc.ca/projects/gamifying-forestry/
@@ -63,7 +63,7 @@ projects:
     surround a quad with a large screen.
   para: >-
     Between November 2021 and June 2022, secondary school students from
-    Aulney-sous-Bois in France have reinvented their neighborhood with Minetest.
+    Aulney-sous-Bois in France have reinvented their neighborhood with Luanti.
     This project, coordinated by the IRI foundation and the teachers, allowed
     the students to explore the digital practice of cooperative and contributive
     construction. The projects created emphasized well-being and the
@@ -91,7 +91,7 @@ projects:
   country: fr
   img: maubeuge.webp
   alt: >-
-    On the left, pupils playing Minetest on laptops.
+    On the left, pupils playing Luanti on laptops.
     On the right, a voxel reconstruction of a city.
   para: >-
     A Workshop for the city of Maubeuge in France where groups of young citizens
@@ -118,11 +118,11 @@ projects:
 
 resources:
 
-- title: Build Block Worlds with Minetest
+- title: Build Block Worlds with Luanti
   author: Miguel Guhlin
   tag: Guide
   para: >-
-    An article explaining why you should use Minetest for education, and a guide
+    An article explaining why you should use Luanti for education, and a guide
     in doing so.
   url: https://blog.tcea.org/build-block-worlds-with-minetest/
 
@@ -130,7 +130,7 @@ resources:
   author: Paul Brown, OS Mag
   tag: Guide
   para: >-
-    Another article explaining why you should use Minetest for education, and a guide
+    Another article explaining why you should use Luanti for education, and a guide
     in doing so.
   url: https://www.ocsmag.com/mining-for-education/
 
@@ -142,8 +142,8 @@ resources:
     pre-school.
   url: http://teachersqueaks.blogspot.co.za/2016/08/minewhat-rolling-out-minetest-in-pre.html
 
-- title: Minetest Wiki (Edu page)
-  author: Minetest community
+- title: Luanti Wiki (Edu page)
+  author: Luanti community
   tag: Guides
   para: >-
     A trove of information, in multiple languages, with a space dedicated to
@@ -151,8 +151,8 @@ resources:
   url: https://wiki.minetest.net/MinetestEDU
 
 - title: ContentDB
-  author: Minetest community
-  tag: To find Minetest mods
+  author: Luanti community
+  tag: To find Luanti mods
   para: >-
     A database where modders can submit their mods, games, and texture packs to
     make them easily accessible. Includes features such as a tag system,
@@ -172,18 +172,18 @@ resources:
   author: BuckarooBanzai
   tag: To share builds
   para: >-
-    A website and mod that allows you to import or share Minetest constructions
+    A website and mod that allows you to import or share Luanti constructions
     on an online library.
   url: https://blockexchange.minetest.ch/
 
 - title: Create/host a server (Wiki)
-  author: Minetest community
+  author: Luanti community
   tag: To host a server by yourself
   para: The basics to host your multiplayer world locally or online.
   url: https://wiki.minetest.net/Setting_up_a_server
 
-- title: Minetest Modding Book
+- title: Luanti Modding Book
   author: rubenwardy
   tag: To learn how to make mods
-  para: Learn how to use Minetest's Lua API to create mods and games.
+  para: Learn how to use Luanti's Lua API to create mods and games.
   url: https://rubenwardy.com/minetest_modding_book/

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -40,7 +40,7 @@ developers:
 
     - title: Modding API
       description: >
-        Use the same Lua API to make mods for any Minetest-based game.
+        Use the same Lua API to make mods for any Luanti-based game.
         Publish your mods on [ContentDB](https://content.minetest.net),
         and contribute to others' mods.
 

--- a/_data/press.yml
+++ b/_data/press.yml
@@ -22,7 +22,7 @@ resources:
   - title: Stickers
     author: erlehmann and Lemente
     img: sticker.png
-    para: A Minetest sticker.
+    para: A Luanti sticker.
     url: https://gitlab.com/rubenwardy/fosdem24/-/tree/main/stickers?ref_type=heads
 
   - title: Presentation Flipbook

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="columns is-multiline">
 
       <div class="column is-6-mobile">
-        <h5 class="footer-title">Minetest</h5>
+        <h5 class="footer-title">Luanti</h5>
         <ul class="list-unstyled">
           <li><a href="{{ '/downloads/' | relative_url }}">Downloads</a></li>
           <li><a href="https://blog.minetest.net/">News</a></li>
@@ -52,7 +52,7 @@
           <li><a href="https://dev.minetest.net/Main_Page">Developer Wiki</a></li>
           <li><a href="https://api.minetest.net">Lua API reference</a></li>
           <li><a href="{{ '/get-involved/#donate' | relative_url }}">Donate</a></li>
-          <li><a href="https://rubenwardy.com/minetest_modding_book/">Minetest Modding Book</a></li>
+          <li><a href="https://rubenwardy.com/minetest_modding_book/">Luanti Modding Book</a></li>
         </ul>
       </div>
 
@@ -60,7 +60,7 @@
   </div>
 
   <div class="footer-copyright">
-    © 2015-{{ site.time | date: '%Y' }} The Minetest Team.
+    © 2015-{{ site.time | date: '%Y' }} The Luanti Team.
     <a href="https://github.com/minetest/minetest.github.io">Source</a><br />
     MIT for code, CC-BY-SA 3.0 for content, media under
     <a href="https://github.com/minetest/minetest.github.io/#license">various licenses</a>.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,12 +2,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
     {{ page.title }}
-    {% unless page.title_append == false %}- Minetest {% endunless %}
+    {% unless page.title_append == false %}- Luanti {% endunless %}
 </title>
 <link rel="canonical" href="https://www.minetest.net{{ page.url }}">
 <meta name="og:url" content="https://www.minetest.net{{ page.url }}">
 <meta name="og:title" content="{{ page.title | escape }}">
-<meta name="og:site_name" content="Minetest">
+<meta name="og:site_name" content="Luanti">
 {% if page.description %}
   <meta name="og:description" content="{{ page.description | escape | strip }}">
   <meta name="description" content="{{ page.description | escape | strip }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,8 +8,8 @@
   <div class="container">
     <div class="navbar-brand">
       <a class="navbar-item" href="{{ '/' | relative_url }}">
-        <img alt="Minetest logo" src="/media/icon.svg">
-        <div class="has-text-weight-bold navbar-brand-text">Minetest</div>
+        <img alt="Luanti logo" src="/media/icon.svg">
+        <div class="has-text-weight-bold navbar-brand-text">Luanti</div>
       </a>
 
       <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar">

--- a/app-privacy-policy.md
+++ b/app-privacy-policy.md
@@ -1,6 +1,6 @@
 ---
-title: Minetest Privacy Policy
-description: Privacy policy for the Minetest application.
+title: Luanti Privacy Policy
+description: Privacy policy for the Luanti application.
 small: |
   Last updated: 2024-08-17
   (<a href="https://github.com/minetest/minetest.github.io/commits/master/app-privacy-policy.md">View updates</a>)
@@ -13,14 +13,14 @@ layout: page_subtitle
 	}
 </style>
 
-Minetest may connect to the following services during its operation:
+Luanti may connect to the following services during its operation:
 
 * The main website (www.minetest.net): used to get the most recent version
 * The server list: used to load the server list in "Play Online"
 * ContentDB: used to install/update content in the main menu
 * Game servers: third-party servers when playing online
 
-Note: this policy only applies to the Minetest application, accessing the
+Note: this policy only applies to the Luanti application, accessing the
 mentioned services directly using a web browser is not covered.
 
 ### Table of contents
@@ -50,11 +50,11 @@ mentioned services directly using a web browser is not covered.
 
 ### Information collected
 
-When you open the Play Online tab, Minetest will request the server list.
+When you open the Play Online tab, Luanti will request the server list.
 The following information will be transferred or included:
 
 * IP address
-* Minetest version
+* Luanti version
 * Platform and Operating System
 
 ### How it is used
@@ -90,13 +90,13 @@ transferred or included:
 
 * IP address
 * Page URL
-* Minetest version
+* Luanti version
 * Platform and Operating System
 
 for example:
 
 ```
-11.22.33.44 content.minetest.net - [06/July/2024:10:05:00 +0200] "GET /packages/Wuzzy/glitch/releases/18414/download/?reason=new HTTP/2.0" 302 233 "-" "Minetest/5.8.0 (Windows/10.0.19041 x86_64)"
+11.22.33.44 content.minetest.net - [06/July/2024:10:05:00 +0200] "GET /packages/Wuzzy/glitch/releases/18414/download/?reason=new HTTP/2.0" 302 233 "-" "Luanti/5.8.0 (Windows/10.0.19041 x86_64)"
 ```
 
 ### How it is used
@@ -139,12 +139,12 @@ See [ContentDB's privacy policy](https://content.minetest.net/privacy_policy/#re
 
 ### Information collected
 
-When you open Minetest, it may contact www.minetest.net to fetch information
+When you open Luanti, it may contact www.minetest.net to fetch information
 about the most recent version. The following information will be transferred or
 included:
 
 * IP address
-* Minetest version
+* Luanti version
 * Platform and Operating System
 
 ### How it is used
@@ -161,8 +161,8 @@ See [About GitHub Pages > Data collection](https://docs.github.com/en/pages/gett
 
 ## Online play
 
-Minetest allows you to play online on multiplayer game servers. Please note that
-game servers are third-party, Minetest acts like a web browser connecting to a
+Luanti allows you to play online on multiplayer game servers. Please note that
+game servers are third-party, Luanti acts like a web browser connecting to a
 website. Therefore, please refer to the game server's privacy policy.
 
 
@@ -174,4 +174,4 @@ We do not share any personal information with third parties.
 ## Future changes to privacy policy
 
 We will alert any future changes to the privacy policy via posts on the
-Minetest forum and by the last updated date at the top of this page.
+Luanti forum and by the last updated date at the top of this page.

--- a/credits.html
+++ b/credits.html
@@ -1,6 +1,6 @@
 ---
 title: Credits
-description: Key contributors and developers behind the Minetest project
+description: Key contributors and developers behind the Luanti project
 layout: default
 redirect_from:
 - /credits.html
@@ -20,8 +20,8 @@ redirect_from:
           responsibilities.
         </p>
         <p>
-          Core developers decide what can be added to Minetest by voting for
-          and against pull requests. They also have commit access to the Minetest
+          Core developers decide what can be added to Luanti by voting for
+          and against pull requests. They also have commit access to the Luanti
           team's repositories on GitHub.
           <a href="https://dev.minetest.net/Organisation">Learn more.</a>
         </p>
@@ -39,8 +39,8 @@ redirect_from:
         <h2>Contributors</h2>
         <p>
           Also see the complete lists of
-          <a href="https://github.com/minetest/minetest/graphs/contributors">Minetest</a> and
           <a href="https://github.com/minetest/minetest_game/graphs/contributors">Minetest Game</a>
+          <a href="https://github.com/minetest/minetest/graphs/contributors">Luanti</a> and
           contributors.
         </p>
 

--- a/credits.html
+++ b/credits.html
@@ -39,8 +39,8 @@ redirect_from:
         <h2>Contributors</h2>
         <p>
           Also see the complete lists of
-          <a href="https://github.com/minetest/minetest_game/graphs/contributors">Minetest Game</a>
           <a href="https://github.com/minetest/minetest/graphs/contributors">Luanti</a> and
+          <a href="https://github.com/minetest/minetest_game/graphs/contributors">Minetest Game</a>
           contributors.
         </p>
 

--- a/downloads.html
+++ b/downloads.html
@@ -1,6 +1,6 @@
 ---
 title: Downloads
-description: Download the latest version of Minetest
+description: Download the latest version of Luanti
 layout: default
 redirect_from:
   - /downloads.html
@@ -32,6 +32,21 @@ redirect_from:
       top of a game in order to customize your experience further.
     </p>
 
+    <div class="notification is-info">
+      <p><strong>Please excuse the mess!</strong></p>
+
+      <p>
+        We are
+        <a href="https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/">currently renaming from Minetest to Luanti</a>.
+        The name change will be applied to the engine in version 5.10.0,
+        but until then you will be downloading a "Luanti" that calls itself Minetest.
+      </p>
+
+      <p>
+        There are also inconsistent mentions of the old name in places that haven't been updated, but will be shortly.
+      </p>
+    </div>
+
     <hr>
     <div class="columns is-multiline">
 
@@ -43,21 +58,21 @@ redirect_from:
         <ul>
           <li class="has-text-weight-bold">
             <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-win64.zip">
-              Minetest 5.9.1 - portable, 64-bit (recommended)
+              Luanti 5.9.1 - portable, 64-bit (recommended)
             </a>
           </li>
           <li>
             <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-win32.zip">
-              Minetest 5.9.1 - portable, 32-bit
+              Luanti 5.9.1 - portable, 32-bit
             </a>
           </li>
         </ul>
         <p>
           Stuck? See
-          <a href="https://wiki.minetest.net/Getting_Started#Windows">help on getting Minetest on Windows.</a>
+          <a href="https://wiki.minetest.net/Getting_Started#Windows">help on getting Luanti on Windows.</a>
         </p>
         <p>
-          You can also get the latest development version of Minetest from
+          You can also get the latest development version of Luanti from
           <a href="https://forum.minetest.net/viewforum.php?f=42">builds made by community members</a>.
           These builds are more recent than the officially released builds
           and contain new features (at the cost of stability).
@@ -142,7 +157,7 @@ redirect_from:
         <p>On FreeBSD 9.1 and newer, you can use the official pre-built packages:
             <code>pkg install minetest</code></p>
         <h3>Compile using ports</h3>
-        <p>You can also compile Minetest and choose build options easily using the FreeBSD port dialogs.</p>
+        <p>You can also compile Luanti and choose build options easily using the FreeBSD port dialogs.</p>
         <pre>
 cd /usr/ports/games/minetest
 make install
@@ -155,7 +170,7 @@ make install
         <ul>
           <li class="has-text-weight-bold">
             <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-macos.zip">
-              Minetest 5.9.1 - App
+              Luanti 5.9.1 - App
             </a>
           </li>
           <li>
@@ -178,7 +193,7 @@ make install
         </p>
         <p>
           See the <a href="https://github.com/minetest/minetest/blob/master/README.md">README</a>
-          for details on how to compile Minetest from source.
+          for details on how to compile Luanti from source.
         </p>
       </div>
     </div>

--- a/downloads.html
+++ b/downloads.html
@@ -32,21 +32,6 @@ redirect_from:
       top of a game in order to customize your experience further.
     </p>
 
-    <div class="notification is-info">
-      <p><strong>Please excuse the mess!</strong></p>
-
-      <p>
-        We are
-        <a href="https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/">currently renaming from Minetest to Luanti</a>.
-        The name change will be applied to the engine in version 5.10.0,
-        but until then you will be downloading a "Luanti" that calls itself Minetest.
-      </p>
-
-      <p>
-        There are also inconsistent mentions of the old name in places that haven't been updated, but will be shortly.
-      </p>
-    </div>
-
     <hr>
     <div class="columns is-multiline">
 

--- a/education.html
+++ b/education.html
@@ -1,6 +1,6 @@
 ---
-title: Minetest for Education
-description: Reasons and resources for using Minetest in education
+title: Luanti for Education
+description: Reasons and resources for using Luanti in education
 layout: default
 ---
 
@@ -8,7 +8,7 @@ layout: default
 
 <section class="section">
   <div class="container">
-    <h2 id="why" class="title">Why Minetest?</h2>
+    <h2 id="why" class="title">Why Luanti?</h2>
     <div class="columns is-multiline">
       {% for point in site.data.edu.why %}
         <div class="column is-one-third">
@@ -58,9 +58,9 @@ layout: default
     <h2 id="get-involved" class="title is-3">Get Involved</h2>
     <div class="columns">
       <article class="column is-half">
-        <h2 class="title is-4">Minetest community</h2>
+        <h2 class="title is-4">Luanti community</h2>
         <p class="my-4">
-          Get involved with the wider Minetest community by joining one
+          Get involved with the wider Luanti community by joining one
           of the official social platforms.
         </p>
         <p>
@@ -70,9 +70,9 @@ layout: default
         </p>
       </article>
       <article class="column is-half">
-        <h2 class="title is-4">Minetest Edu Discord (unofficial)</h2>
+        <h2 class="title is-4">Luanti Edu Discord (unofficial)</h2>
         <p class="my-4">
-          There's an educator-led Discord for the discussion of Minetest in
+          There's an educator-led Discord for the discussion of Luanti in
           education.
         </p>
         <p>

--- a/get-involved.html
+++ b/get-involved.html
@@ -51,7 +51,7 @@ redirect_from:
               Give support on the <a href="https://forum.minetest.net">forums</a> and <a href="https://wiki.minetest.net/IRC">IRC</a>.
             </li>
             <li>
-              Help translate Minetest using
+              Help translate Luanti using
               <a href="https://hosted.weblate.org/projects/minetest/minetest/">our web interface</a>.
             </li>
             <li>
@@ -71,7 +71,7 @@ redirect_from:
             <li>
               Work on a <a href="https://dev.minetest.net/Modding_Intro">game or mod</a>
               and publish it to <a href="https://content.minetest.net">ContentDB</a>.
-              The <a href="https://rubenwardy.com/minetest_modding_book/">Minetest Modding Book</a>
+              The <a href="https://rubenwardy.com/minetest_modding_book/">Luanti Modding Book</a>
               provides an easy introduction to creating mods and games.
             </li>
             <li>
@@ -117,16 +117,16 @@ redirect_from:
 
 <section class="section">
   <div class="container">
-    <h2 id="developed" class="title section-title">How is Minetest developed?</h2>
+    <h2 id="developed" class="title section-title">How is Luanti developed?</h2>
     <div class="content">
       <h3 class="is-size-3">The Process</h3>
       <p>
-        Minetest is developed and maintained by a group of volunteers called
+        Luanti is developed and maintained by a group of volunteers called
         the <a href="https://github.com/orgs/minetest/people">core team</a>,
-        consisting of a bunch of people who are trusted to keep Minetest
+        consisting of a bunch of people who are trusted to keep Luanti
         progressing in good condition.
         The core team is formed of people who have made great
-        <a href="{{ '/credits/' | relative_url }}">contributions</a> to Minetest.
+        <a href="{{ '/credits/' | relative_url }}">contributions</a> to Luanti.
         Contributions are approved if two members of the core team agree on them.
       </p>
       <p>
@@ -150,7 +150,7 @@ redirect_from:
 
       <h3 class="is-size-3">Project Structure</h3>
       <p>
-        Minetest is distributed as an engine, combined with a couple of games.
+        Luanti is distributed as an engine, combined with a couple of games.
         Upstream repositories can be found at
         <a href="https://github.com/minetest/">https://github.com/minetest/</a>.
       </p>
@@ -178,7 +178,7 @@ redirect_from:
 
       <h3 class="is-size-3">Roadmaps and Future Plans</h3>
       <p>
-        As an open source project developed by volunteers, Minetest is
+        As an open source project developed by volunteers, Luanti is
         mostly iteratively developed rather than formally planned. However,
         there are some overarching goals, both medium-term and long-term, that
         have been agreed upon by core developers:
@@ -200,10 +200,10 @@ redirect_from:
     <div class="content">
       <h3 class="is-size-3">Where?</h3>
       <p>
-        Different things related to Minetest are maintained by different people, contacted in different ways. Here you can find where to report issues, bugs and any other kinds of problems regarding to each “product”.
+        Different things related to Luanti are maintained by different people, contacted in different ways. Here you can find where to report issues, bugs and any other kinds of problems regarding to each “product”.
       </p>
       <p>
-        People are generally available on Libera <abbr title="Internet Relay Chat">IRC</abbr>, Discord, the Minetest Forums, GitHub and/or via email.
+        People are generally available on Libera <abbr title="Internet Relay Chat">IRC</abbr>, Discord, the Luanti Forums, GitHub and/or via email.
       </p>
       <table class="table is-striped">
         <tr>
@@ -213,7 +213,7 @@ redirect_from:
           <th>Issue Tracker</th>
         </tr>
         <tr>
-          <td>Minetest Engine</td>
+          <td>Luanti Engine</td>
           <td>Core developers</td>
           <td>
             <a href="https://github.com/minetest/minetest">Source</a>
@@ -320,12 +320,12 @@ redirect_from:
     <h2 id="donate" class="title section-title">Donate</h2>
     <div class="content">
       <p>
-        Minetest doesn't have a legal body to accept donations, and most core
+        Luanti doesn't have a legal body to accept donations, and most core
         developers do not wish to accept donations
         <a href="https://github.com/minetest/minetest.github.io/issues/222">themselves</a>.
       </p>
 
-      <h3 class="is-size-3">Minetest <span class="is-size-5 has-text-grey has-text-weight-normal">(team)</span></h3>
+      <h3 class="is-size-3">Luanti <span class="is-size-5 has-text-grey has-text-weight-normal">(team)</span></h3>
       <p>
         The Liberapay team allows you to support multiple members at the same
         time.
@@ -337,7 +337,7 @@ redirect_from:
       <h3 class="is-size-3">celeron55 <span class="is-size-5 has-text-grey has-text-weight-normal">(founder)</span></h3>
       <p>
         You can tip money to celeron55.
-        He is the original creator of Minetest, and hosts the forums and wikis.
+        He is the original creator of Luanti, and hosts the forums and wikis.
         While he isn't involved in active development, he plays an advisory
         role and breaks ties.
       </p>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-title: Minetest | Open source voxel game engine
+title: Luanti | Open source voxel game engine
 description: >-
   An open source voxel game engine. Play one of our many games, mod a game to
   your liking, make your own game, or play on a multiplayer server.
@@ -15,7 +15,7 @@ redirect_from:
   <div class="container">
     <div class="columns is-centered">
       <div class="column is-10 is-9-desktop is-8-widescreen is-7-fullhd">
-        <h1 class="title">Minetest</h1>
+        <h1 class="title">Luanti (formerly Minetest)</h1>
         <p class="home-paragraph">
           An open source voxel game engine.
           Play one of our many games, mod a game to your liking, make your own game,
@@ -66,7 +66,7 @@ redirect_from:
 <section class="section">
   <div class="container is-max-desktop blog-embed">
     <h2 id="blog" class="title section-title">Blog</h2>
-    <iframe src="https://blog.minetest.net/embed_latest/" title="Latest Minetest Blog Post" frameborder="0"></iframe>
+    <iframe src="https://blog.minetest.net/embed_latest/" title="Latest Luanti Blog Post" frameborder="0"></iframe>
     <p>
       <a class="button is-primary" href="https://blog.minetest.net/">
         View more blog posts

--- a/servers.html
+++ b/servers.html
@@ -1,6 +1,6 @@
 ---
 title: Server list
-description: A list of public servers, as shown inside Minetest
+description: A list of public servers, as shown inside Luanti
 layout: default
 redirect_from:
   - /servers.html


### PR DESCRIPTION
Renames most occurences of Minetest on the landing page to Luanti.

Some occurences have been left alone such as mentions to press resources that haven't been renamed yet. I left them not renamed as a reminder.

A "(formerly Minetest)" is added to the title of the index page.

I also added a note on the download page to reduce any confusion before 5.10.0 is out and the rename comes to the engine, so it can be merged right away:

![image](https://github.com/user-attachments/assets/b17edfb3-dedd-4867-a707-a89e71310264)

~~Bikeshedding~~ Feedback on the phrasing welcome, but I assume it can also be removed once 5.10.0 comes out which would be soon.