### PR TITLE
Read latest version in downloads from release data

### DIFF
--- a/_data/release.yml
+++ b/_data/release.yml
@@ -4,5 +4,4 @@ latest:
   date: "2024-09-15"
   protocol_version: 45
   url: "https://www.minetest.net/downloads/"
-  # Header for the latest changelog entry on the Wiki
-  changelog_header: "5.9.0_.E2.86.92_5.9.1"
+  changelog_url: "https://dev.minetest.net/Changelog#5.9.0_.E2.86.92_5.9.1"

--- a/_data/release.yml
+++ b/_data/release.yml
@@ -4,3 +4,5 @@ latest:
   date: "2024-09-15"
   protocol_version: 45
   url: "https://www.minetest.net/downloads/"
+  # Header for the latest changelog entry on the Wiki
+  changelog_header: "5.9.0_.E2.86.92_5.9.1"

--- a/downloads.html
+++ b/downloads.html
@@ -11,6 +11,8 @@ redirect_from:
   - /other_distros/
 ---
 
+{% assign latest_ver = site.data.release.latest.version %}
+
 <section class="section">
   <div class="container content">
 
@@ -42,13 +44,13 @@ redirect_from:
         </p>
         <ul>
           <li class="has-text-weight-bold">
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-win64.zip">
-              Minetest 5.9.1 - portable, 64-bit (recommended)
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-win64.zip">
+              Minetest {{ latest_ver }} - portable, 64-bit (recommended)
             </a>
           </li>
           <li>
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-win32.zip">
-              Minetest 5.9.1 - portable, 32-bit
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-win32.zip">
+              Minetest {{ latest_ver }} - portable, 32-bit
             </a>
           </li>
         </ul>
@@ -80,13 +82,13 @@ redirect_from:
         <ul>
           <li>
             ARM:
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-arm64-v8a.apk">64-bit</a> -
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-armeabi-v7a.apk">32-bit</a>
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-arm64-v8a.apk">64-bit</a> -
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-armeabi-v7a.apk">32-bit</a>
           </li>
           <li>
             x86:
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-x86_64.apk">64-bit</a> -
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-x86.apk">32-bit</a>
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-x86_64.apk">64-bit</a> -
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-x86.apk">32-bit</a>
           </li>
         </ul>
         <p>
@@ -154,8 +156,8 @@ make install
         <p>macOS 12 or later is recommended.</p>
         <ul>
           <li class="has-text-weight-bold">
-            <a href="https://github.com/minetest/minetest/releases/download/5.9.1/minetest-5.9.1-macos.zip">
-              Minetest 5.9.1 - App
+            <a href="https://github.com/minetest/minetest/releases/download/{{ latest_ver }}/minetest-{{ latest_ver }}-macos.zip">
+              Minetest {{ latest_ver }} - App
             </a>
           </li>
           <li>

--- a/downloads.html
+++ b/downloads.html
@@ -23,7 +23,7 @@ redirect_from:
       Have a look at our <a href="https://wiki.minetest.net/Getting_Started">Getting Started</a>,
       <a href="https://wiki.minetest.net/FAQ">FAQ</a>,
        and <a href="https://wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
-      Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#5.9.0_.E2.86.92_5.9.1">changelog</a>.
+      Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#{{ site.data.release.latest.changelog_header }}">changelog</a>.
     </p>
     <p>
       You may also want to look at some

--- a/downloads.html
+++ b/downloads.html
@@ -23,7 +23,7 @@ redirect_from:
       Have a look at our <a href="https://wiki.minetest.net/Getting_Started">Getting Started</a>,
       <a href="https://wiki.minetest.net/FAQ">FAQ</a>,
        and <a href="https://wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
-      Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#{{ site.data.release.latest.changelog_header }}">changelog</a>.
+      Otherwise, feel free to look at the <a href="{{ site.data.release.latest.changelog_url }}">changelog</a>.
     </p>
     <p>
       You may also want to look at some


### PR DESCRIPTION
Simplifies things slightly during release, updating the release data in `_data/release.yml` will update the downloads page.