### PR TITLE
Updating arch linux package query link for stable package

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -117,7 +117,7 @@ redirect_from:
             or compile from source, as the repos are outdated
           </li>
           <li>Arch Linux -
-              <a href="https://archlinux.org/packages/?q=minetest">Stable</a>,
+              <a href="https://archlinux.org/packages/?q=luanti">Stable</a>,
               <a href="https://aur.archlinux.org/packages/minetest-git/">Unstable (AUR)</a></li>
           <li>Fedora -
               <a href="https://src.fedoraproject.org/rpms/minetest">Stable</a></li>


### PR DESCRIPTION
Updating arch linux package query link for stable package on downloads page

The AUR link still looks fine, though