### PR TITLE
Downloads: Move community builds to source code section

### DIFF
--- a/_includes/pages/downloads.html
+++ b/_includes/pages/downloads.html
@@ -49,13 +49,6 @@ layout: base
 						</a>
 					</li>
 				</ul>
-				<p>
-					{{ "You can also get the latest development version of Luanti from
-					<a href='https://forum.luanti.org/viewforum.php?f=42'>builds made by community members</a>." | i18n
-					}}
-					{{ "These builds are more recent than the officially released builds
-					and contain new features (at the cost of stability)." | i18n }}
-				</p>
 			</div>
 
 			<div class="column is-12-tablet is-6-desktop">
@@ -246,7 +239,14 @@ make install
 			</div>
 
 			<div class="column is-12-tablet is-6-desktop">
-				<h2>{{ "Source code" | i18n }}</h2>
+				<h2>{{ "Community builds and Source code" | i18n }}</h2>
+				<p>
+					{{ "You can also get the latest development version of Luanti from
+					<a href='https://forum.luanti.org/viewforum.php?f=42'>builds made by community members</a>." | i18n
+					}}
+					{{ "These builds are more recent than the officially released builds
+					and contain new features (at the cost of stability)." | i18n }}
+				</p>
 				<p>
 					{{ "Get the latest <a href='https://github.com/luanti-org/luanti/tree/stable-5'>stable</a>
 					or <a href='https://github.com/luanti-org/luanti'>development</a> source code from


### PR DESCRIPTION
I've moved the Community builds from the Windows section to the source code section to resolve issue #116.
The Translations should be updated.