### PR TITLE
Fetch CDB mod count for homepage

### DIFF
--- a/_data/contentdb_mod_count.js
+++ b/_data/contentdb_mod_count.js
@@ -1,0 +1,15 @@
+import EleventyFetch from "@11ty/eleventy-fetch";
+
+const API = "https://content.luanti.org/api/packages/?type=mod";
+const CACHE = process.env.CONTENTDB_CACHE || "6h";
+
+export default async function () {
+	try {
+		const data = await EleventyFetch(API, { duration: CACHE, type: "json", fetchOptions: { headers: { Accept: "application/json" } } });
+		const count = data.length;
+		return Math.floor(count / 100) * 100;
+	} catch (err) {
+		console.error("contentdb_mod_count fetch failed:", err && err.message ? err.message : err);
+		return null;
+	}
+}

--- a/_data/contentdb_mod_count.js
+++ b/_data/contentdb_mod_count.js
@@ -9,7 +9,7 @@ export default async function () {
 		const count = data.length;
 		return Math.floor(count / 100) * 100;
 	} catch (err) {
-		console.error("contentdb_mod_count fetch failed:", err && err.message ? err.message : err);
+		console.error("contentdb_mod_count fetch failed:", err);
 		return null;
 	}
 }

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -48,7 +48,7 @@ developers:
 
     - title: Large Collection of Existing Mods
       description: >
-        There are over 2500 open source mods on
+        There are over {{contentdb_mod_count}} open source mods on
         [ContentDB](https://content.luanti.org/),
         which are ready to be used, adapted or learned from.
 

--- a/_includes/pages/index.html
+++ b/_includes/pages/index.html
@@ -10,6 +10,8 @@ homepage: true
 ---
 
 {% assign langPrefix = "/" | append: lang | append: "/" %}
+{% assign cdbModCount = contentdb_mod_count | default: 2500 %}
+
 
 <section class="section section-home">
 	<div class="container">
@@ -57,7 +59,7 @@ homepage: true
 				{% for feature in category.features %}
 				<h4 class="title feature-title">{{ feature.title | i18n }}</h4>
 				<div class="content">
-					{{ feature.description | i18n | markdownify | replace: "/en/", langPrefix }}
+					{{ feature.description | i18n: "contentdb_mod_count", cdbModCount | markdownify | replace: "/en/", langPrefix }}
 				</div>
 				{% endfor %}
 			</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@11ty/eleventy": "^3.1.2",
+				"@11ty/eleventy-fetch": "^5.1.1",
 				"i18next": "^25.6.0",
 				"i18next-fs-backend": "^2.6.0",
 				"iso-639-1": "^3.1.5",
@@ -116,6 +117,26 @@
 			},
 			"bin": {
 				"eleventy-dev-server": "cmd.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/11ty"
+			}
+		},
+		"node_modules/@11ty/eleventy-fetch": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.1.tgz",
+			"integrity": "sha512-/xFJLCrqKlcnRKIfO9Qjd1QOs4IpvypljXET955+EgdRPFA+h8Or6bDnZBbcwr6KS7yeUuzp5k1DhXgbentSTA==",
+			"license": "MIT",
+			"dependencies": {
+				"@11ty/eleventy-utils": "^2.0.7",
+				"@rgrove/parse-xml": "^4.2.0",
+				"debug": "^4.4.3",
+				"flatted": "^3.3.3",
+				"p-queue": "6.6.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -635,6 +656,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@rgrove/parse-xml": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
+			"integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@sindresorhus/slugify": {
@@ -2479,6 +2509,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"license": "MIT"
+		},
 		"node_modules/events-to-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
@@ -2620,6 +2656,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/flatted": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"license": "ISC"
 		},
 		"node_modules/for-each": {
 			"version": "0.3.5",
@@ -4834,6 +4876,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -4858,6 +4909,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"type": "module",
 	"dependencies": {
 		"@11ty/eleventy": "^3.1.2",
+		"@11ty/eleventy-fetch": "^5.1.1",
 		"i18next": "^25.6.0",
 		"i18next-fs-backend": "^2.6.0",
 		"iso-639-1": "^3.1.5",


### PR DESCRIPTION
> [!NOTE]
> I used an LLM Chatbot/Assistant during development, but I take full responsibility for the submitted changes.

## To do
This PR is ready for review.

This pull request adds a new module that fetches the number of mods from the ContentDB API using `@11ty/eleventy-fetch` and adds it to the `package.json` as a dependency.
The feature description is updated to use a `[[mod_count]]` placeholder instead of a hardcoded number together with the homepage template.